### PR TITLE
Relax setuptools-scm dependency constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "setuptools >= 42",
-    "setuptools_scm[toml]>=3.4,<6",
+    "setuptools_scm[toml]>=3.4",
     "wheel"
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This relaxes the setuptools-scm dependency constraint for PEP 517 builds. It's a companion PR to https://github.com/wheerd/multiset/pull/98.