### PR TITLE
Fix pop and setdefault methods

### DIFF
--- a/multiset.py
+++ b/multiset.py
@@ -1050,6 +1050,9 @@ class Multiset(BaseMultiset):
         Returns:
             The multiplicity for *element* if it is in the multiset, else *default*.
         """
+        rm_size = self._elements.get(element)
+        if rm_size != None:
+            self._total -= rm_size
         return self._elements.pop(element, default)
 
     def setdefault(self, element, default):
@@ -1065,6 +1068,12 @@ class Multiset(BaseMultiset):
         Returns:
             The multiplicity for *element* if it is in the multiset, else *default*.
         """
+
+        mul = self._elements.get(element)
+        if mul == None:
+            if default < 1:
+                raise ValueError("Multiplicity must be positive")
+            self._total += default
         return self._elements.setdefault(element, default)
 
     def clear(self):

--- a/tests/test_multiset.py
+++ b/tests/test_multiset.py
@@ -895,18 +895,18 @@ def test_dict_methods(MultisetCls):
 
 def test_mutating_dict_methods():
     ms = Multiset('aab')
-    initial_size = len(ms)
+    assert len(ms) == len('aab')
 
     assert ms.pop('a', 5) == 2
-    assert len(ms) == initial_size - 2
+    assert len(ms) == len('b')
     assert ms.pop('c', 3) == 3
-    assert len(ms) == initial_size - 2
+    assert len(ms) == len('b')
     assert ['b'] == sorted(ms)
 
     assert ms.setdefault('b', 5) == 1
-    assert len(ms) == initial_size - 2
+    assert len(ms) == len('b')
     assert ms.setdefault('c', 3) == 3
-    assert len(ms) == initial_size + 1
+    assert len(ms) == len('bccc')
     assert ['b', 'c', 'c', 'c'] == sorted(ms)
 
 

--- a/tests/test_multiset.py
+++ b/tests/test_multiset.py
@@ -895,13 +895,18 @@ def test_dict_methods(MultisetCls):
 
 def test_mutating_dict_methods():
     ms = Multiset('aab')
+    initial_size = len(ms)
 
     assert ms.pop('a', 5) == 2
+    assert len(ms) == initial_size - 2
     assert ms.pop('c', 3) == 3
+    assert len(ms) == initial_size - 2
     assert ['b'] == sorted(ms)
 
     assert ms.setdefault('b', 5) == 1
+    assert len(ms) == initial_size - 2
     assert ms.setdefault('c', 3) == 3
+    assert len(ms) == initial_size + 1
     assert ['b', 'c', 'c', 'c'] == sorted(ms)
 
 


### PR DESCRIPTION
The pop and setdefault methods, as they are implemented, just call the corresponding method on the _elements dictionary.
Therefore, if pop is called passing an element contained in the multiset, it results in the element being removed without updating the variable that stores the multiset size.
An analogous thing happens for setdefault because, when it is called passing an element not contained inside the multiset, this item is added with the given multiplicity but the multiset size is not updated.